### PR TITLE
fix: use ImportError for xma module availability check

### DIFF
--- a/sonicmoe/moe.py
+++ b/sonicmoe/moe.py
@@ -17,7 +17,7 @@ try:
     from xma.modules.moe import scattered_experts
 
     _IS_XMA_AVAILABLE = True
-except:
+except ImportError:
     _IS_XMA_AVAILABLE = False
 
 


### PR DESCRIPTION
Replace bare `except:` with `except ImportError:` for the xma module import check in `sonicmoe/moe.py`.