### PR TITLE
Added concatenated layout support

### DIFF
--- a/sonicmoe/functional/__init__.py
+++ b/sonicmoe/functional/__init__.py
@@ -70,6 +70,7 @@ class _UpProjection(torch.autograd.Function):
         is_varlen_K: bool,
         activation_type: ActivationType,
         is_inference_mode_enabled: bool,
+        is_concatenated_gate_up: bool = False,
     ) -> torch.Tensor:
         T, H = x.shape
         I, H, E = w1.shape
@@ -105,6 +106,7 @@ class _UpProjection(torch.autograd.Function):
                 activation_type=activation_type.value,
                 is_glu_activation=is_glu_activation,
                 is_inference_mode_enabled=is_inference_mode_enabled,
+                is_concatenated_gate_up=is_concatenated_gate_up,
             )
 
         ctx.T = T
@@ -115,6 +117,7 @@ class _UpProjection(torch.autograd.Function):
         ctx.I = I
         ctx.is_varlen_K = is_varlen_K
         ctx.is_glu_activation = is_glu_activation
+        ctx.is_concatenated_gate_up = is_concatenated_gate_up
         ctx.stream_id = stream_id
 
         ctx.save_for_backward(
@@ -146,6 +149,7 @@ class _UpProjection(torch.autograd.Function):
         K = ctx.K
         H = ctx.H
         is_glu_activation = ctx.is_glu_activation
+        is_concatenated_gate_up = ctx.is_concatenated_gate_up
         is_varlen_K = ctx.is_varlen_K
         stream_id = ctx.stream_id
 
@@ -190,6 +194,7 @@ class _UpProjection(torch.autograd.Function):
                 s_scatter_idx=s_scatter_idx,
                 is_glu_activation=is_glu_activation,
                 stream_id=stream_id,
+                is_concatenated_gate_up=is_concatenated_gate_up,
             )
 
             _up_projection_backward_weight(
@@ -201,6 +206,7 @@ class _UpProjection(torch.autograd.Function):
                 x_gather_idx=x_gather_idx,
                 is_glu_activation=is_glu_activation,
                 stream_id=stream_id,
+                is_concatenated_gate_up=is_concatenated_gate_up,
             )
 
         dx_reduced = torch.empty(T, H, dtype=dz.dtype, device=dz.device)
@@ -215,7 +221,7 @@ class _UpProjection(torch.autograd.Function):
             is_varlen_K=is_varlen_K,
         )
 
-        return dx_reduced, dw1, db1, *[None] * 12
+        return dx_reduced, dw1, db1, *[None] * 13
 
 
 class _DownProjection(torch.autograd.Function):
@@ -486,6 +492,7 @@ def moe_general_routing_inputs(
     stream_id: int,
     activation_type: ActivationType,
     is_inference_mode_enabled: bool = False,
+    is_concatenated_gate_up: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     assert ((b1 is None) and (b2 is None)) or (
         (b1 is not None) and (b2 is not None)
@@ -531,6 +538,7 @@ def moe_general_routing_inputs(
         True,  # is_varlen_K
         activation_type,
         is_inference_mode_enabled,
+        is_concatenated_gate_up,
     )
 
     o = _DownProjection.apply(

--- a/sonicmoe/functional/backward.py
+++ b/sonicmoe/functional/backward.py
@@ -205,6 +205,7 @@ def _up_projection_backward_act(
     s_scatter_idx: torch.Tensor,
     is_glu_activation: bool,
     stream_id: int,
+    is_concatenated_gate_up: bool = False,
 ) -> None:
     I, H, E = w1.size()
     if is_glu_activation:
@@ -227,9 +228,10 @@ def _up_projection_backward_act(
         mE_permute_order = convert_torch_tensor_to_cute_tensor(expert_schedule_order, (0,), 0, 4, 1, stream=stream_id)
     current_stream = cuda.CUstream(stream_id)
 
-    compile_dx_key = ("dx", E, H, I, is_glu_activation, dx_expanded.dtype)
+    compile_dx_key = ("dx", E, H, I, is_glu_activation, dx_expanded.dtype, is_concatenated_gate_up)
     if compile_dx_key not in _up_projection_backward_act.compile_cache:
-        dx_module = HopperWgmma_MoE_Up_proj_ActGrad_Bwd(E, H, I, is_glu_activation)
+        dx_module = HopperWgmma_MoE_Up_proj_ActGrad_Bwd(E, H, I, is_glu_activation,
+                                                         is_concatenated_gate_up=is_concatenated_gate_up)
         tensormaps = [dx_module.module.generate_tensormap(None, None, None) for _ in range(2)]
         _up_projection_backward_act.compile_cache[compile_dx_key] = cute.compile(
             dx_module,
@@ -243,9 +245,9 @@ def _up_projection_backward_act(
             mE_permute_order,
             current_stream,
         )
-        _up_projection_backward_act.compile_cache[f"dx-{TENSORMAP}"] = tensormaps
+        _up_projection_backward_act.compile_cache[(TENSORMAP, compile_dx_key)] = tensormaps
 
-    dx_tensormaps = _up_projection_backward_act.compile_cache[f"dx-{TENSORMAP}"]
+    dx_tensormaps = _up_projection_backward_act.compile_cache[(TENSORMAP, compile_dx_key)]
     _up_projection_backward_act.compile_cache[compile_dx_key](
         mDz,
         mW1_trans,
@@ -272,6 +274,7 @@ def _up_projection_backward_weight(
     x_gather_idx: torch.Tensor,
     is_glu_activation: bool,
     stream_id: int,
+    is_concatenated_gate_up: bool = False,
 ) -> None:
     I, H, E = dw1.size()
     if is_glu_activation:
@@ -292,9 +295,10 @@ def _up_projection_backward_weight(
         mE_permute_order = convert_torch_tensor_to_cute_tensor(expert_schedule_order, (0,), 0, 4, 1, stream=stream_id)
     current_stream = cuda.CUstream(stream_id)
 
-    compile_dw1_key = ("dw1", E, H, I, is_glu_activation, x.dtype)
+    compile_dw1_key = ("dw1", E, H, I, is_glu_activation, x.dtype, is_concatenated_gate_up)
     if compile_dw1_key not in _up_projection_backward_weight.compile_cache:
-        dw1_module = HopperWgmma_MoE_Up_proj_WeightGrad_Bwd(E, H, I, is_glu_activation)
+        dw1_module = HopperWgmma_MoE_Up_proj_WeightGrad_Bwd(E, H, I, is_glu_activation,
+                                                              is_concatenated_gate_up=is_concatenated_gate_up)
         tensormaps = [dw1_module.module.generate_tensormap(None, None, None) for _ in range(1)]
         _up_projection_backward_weight.compile_cache[compile_dw1_key] = cute.compile(
             dw1_module,
@@ -307,9 +311,9 @@ def _up_projection_backward_weight(
             mE_permute_order,
             current_stream,
         )
-        _up_projection_backward_weight.compile_cache[f"dw1-{TENSORMAP}"] = tensormaps
+        _up_projection_backward_weight.compile_cache[(TENSORMAP, compile_dw1_key)] = tensormaps
 
-    dw1_tensormaps = _up_projection_backward_weight.compile_cache[f"dw1-{TENSORMAP}"]
+    dw1_tensormaps = _up_projection_backward_weight.compile_cache[(TENSORMAP, compile_dw1_key)]
     _up_projection_backward_weight.compile_cache[compile_dw1_key](
         mX_trans,
         mDz_trans,
@@ -405,14 +409,14 @@ def _down_projection_backward_act(
             mE_permute_order,
             current_stream,
         )
-        _down_projection_backward_act.compile_cache[f"dz-{TENSORMAP}"] = tensormaps
+        _down_projection_backward_act.compile_cache[(TENSORMAP, compile_dz_key)] = tensormaps
 
     if ds_partial is None:
         ds_partial_N = _down_projection_backward_act.compile_cache["ds_partial_N"]
         ds_partial = torch.empty(TK, ds_partial_N, dtype=torch.float32, device=topk_scores.device)
         mDS_partial = convert_torch_tensor_to_cute_tensor(ds_partial, (0, 1), 1, 4, 1, stream=stream_id)
 
-    dz_tensormaps = _down_projection_backward_act.compile_cache[f"dz-{TENSORMAP}"]
+    dz_tensormaps = _down_projection_backward_act.compile_cache[(TENSORMAP, compile_dz_key)]
     _down_projection_backward_act.compile_cache[compile_dz_key](
         mDout,
         mW2_trans,
@@ -519,9 +523,9 @@ def _down_projection_backward_weight(
             mE_permute_order,
             current_stream,
         )
-        _down_projection_backward_weight.compile_cache[f"dw2-{TENSORMAP}"] = tensormaps
+        _down_projection_backward_weight.compile_cache[(TENSORMAP, compile_dw2_key)] = tensormaps
 
-    dw2_tensormaps = _down_projection_backward_weight.compile_cache[f"dw2-{TENSORMAP}"]
+    dw2_tensormaps = _down_projection_backward_weight.compile_cache[(TENSORMAP, compile_dw2_key)]
     _down_projection_backward_weight.compile_cache[compile_dw2_key](
         mDout_trans, mY1S_trans, mDw2, mE_offset, mX_gather, dw2_tensormaps, mE_permute_order, current_stream
     )

--- a/sonicmoe/functional/backward.py
+++ b/sonicmoe/functional/backward.py
@@ -230,8 +230,7 @@ def _up_projection_backward_act(
 
     compile_dx_key = ("dx", E, H, I, is_glu_activation, dx_expanded.dtype, is_concatenated_gate_up)
     if compile_dx_key not in _up_projection_backward_act.compile_cache:
-        dx_module = HopperWgmma_MoE_Up_proj_ActGrad_Bwd(E, H, I, is_glu_activation,
-                                                         is_concatenated_gate_up=is_concatenated_gate_up)
+        dx_module = HopperWgmma_MoE_Up_proj_ActGrad_Bwd(E, H, I, is_glu_activation, is_concatenated_gate_up=is_concatenated_gate_up)
         tensormaps = [dx_module.module.generate_tensormap(None, None, None) for _ in range(2)]
         _up_projection_backward_act.compile_cache[compile_dx_key] = cute.compile(
             dx_module,
@@ -297,8 +296,7 @@ def _up_projection_backward_weight(
 
     compile_dw1_key = ("dw1", E, H, I, is_glu_activation, x.dtype, is_concatenated_gate_up)
     if compile_dw1_key not in _up_projection_backward_weight.compile_cache:
-        dw1_module = HopperWgmma_MoE_Up_proj_WeightGrad_Bwd(E, H, I, is_glu_activation,
-                                                              is_concatenated_gate_up=is_concatenated_gate_up)
+        dw1_module = HopperWgmma_MoE_Up_proj_WeightGrad_Bwd(E, H, I, is_glu_activation, is_concatenated_gate_up=is_concatenated_gate_up)
         tensormaps = [dw1_module.module.generate_tensormap(None, None, None) for _ in range(1)]
         _up_projection_backward_weight.compile_cache[compile_dw1_key] = cute.compile(
             dw1_module,

--- a/sonicmoe/functional/forward.py
+++ b/sonicmoe/functional/forward.py
@@ -92,8 +92,7 @@ def _up_projection_forward(
     compile_w1_key = (E, H, I, (b1 is None), x.dtype, activation_type, is_inference_mode_enabled, is_concatenated_gate_up)
     if compile_w1_key not in _up_projection_forward.compile_cache:
         w1_module = HopperWgmma_MoE_Up_proj_Fwd(
-            E, H, I, activation_type=ActivationType(activation_type), inference_mode=is_inference_mode_enabled,
-            is_concatenated_gate_up=is_concatenated_gate_up,
+            E, H, I, activation_type=ActivationType(activation_type), inference_mode=is_inference_mode_enabled, is_concatenated_gate_up=is_concatenated_gate_up,
         )
         tensormaps = [w1_module.module.generate_tensormap(None, None, None) for _ in range(2)]
         _up_projection_forward.compile_cache[compile_w1_key] = cute.compile(

--- a/sonicmoe/functional/forward.py
+++ b/sonicmoe/functional/forward.py
@@ -64,6 +64,7 @@ def _up_projection_forward(
     activation_type: str,
     is_glu_activation: bool,
     is_inference_mode_enabled: bool = False,
+    is_concatenated_gate_up: bool = False,
 ) -> None:
     I, H, E = w1.size()
     if is_glu_activation:
@@ -88,10 +89,11 @@ def _up_projection_forward(
 
     current_stream = cuda.CUstream(stream_id)
 
-    compile_w1_key = (E, H, I, (b1 is None), x.dtype, activation_type, is_inference_mode_enabled)
+    compile_w1_key = (E, H, I, (b1 is None), x.dtype, activation_type, is_inference_mode_enabled, is_concatenated_gate_up)
     if compile_w1_key not in _up_projection_forward.compile_cache:
         w1_module = HopperWgmma_MoE_Up_proj_Fwd(
-            E, H, I, activation_type=ActivationType(activation_type), inference_mode=is_inference_mode_enabled
+            E, H, I, activation_type=ActivationType(activation_type), inference_mode=is_inference_mode_enabled,
+            is_concatenated_gate_up=is_concatenated_gate_up,
         )
         tensormaps = [w1_module.module.generate_tensormap(None, None, None) for _ in range(2)]
         _up_projection_forward.compile_cache[compile_w1_key] = cute.compile(
@@ -108,9 +110,9 @@ def _up_projection_forward(
             mE_permute_order,
             current_stream,
         )
-        _up_projection_forward.compile_cache[TENSORMAP] = tensormaps
+        _up_projection_forward.compile_cache[(TENSORMAP, compile_w1_key)] = tensormaps
 
-    w1_tensormaps = _up_projection_forward.compile_cache[TENSORMAP]
+    w1_tensormaps = _up_projection_forward.compile_cache[(TENSORMAP, compile_w1_key)]
     _up_projection_forward.compile_cache[compile_w1_key](
         mX,
         mW1,
@@ -167,9 +169,9 @@ def _down_projection_forward(
         _down_projection_forward.compile_cache[compile_w2_key] = cute.compile(
             w2_module, mY1, mW2, mY2, mB2, mE_offset, mX_gather, tensormaps[0], mE_permute_order, current_stream
         )
-        _down_projection_forward.compile_cache[TENSORMAP] = tensormaps
+        _down_projection_forward.compile_cache[(TENSORMAP, compile_w2_key)] = tensormaps
 
-    w2_tensormaps = _down_projection_forward.compile_cache[TENSORMAP]
+    w2_tensormaps = _down_projection_forward.compile_cache[(TENSORMAP, compile_w2_key)]
     _down_projection_forward.compile_cache[compile_w2_key](
         mY1, mW2, mY2, mB2, mE_offset, mX_gather, w2_tensormaps[0], mE_permute_order, current_stream
     )

--- a/sonicmoe/functional/moe_config.py
+++ b/sonicmoe/functional/moe_config.py
@@ -37,8 +37,9 @@ class HopperGEMMConfig:
 
 
 class HopperWgmma_MoE_Up_proj_Fwd:
-    def __init__(self, E: int, H: int, I: int, activation_type: ActivationType, inference_mode=False):
+    def __init__(self, E: int, H: int, I: int, activation_type: ActivationType, inference_mode=False, is_concatenated_gate_up: bool = False):
         super().__init__()
+        self.is_concatenated_gate_up = is_concatenated_gate_up
         is_glu_activation = is_glu(activation_type)
         if is_glu_activation:
             assert (
@@ -127,6 +128,15 @@ class HopperWgmma_MoE_Up_proj_Fwd:
     def __call__(
         self, mX, mW1, mZ, mY1, mB1, mE_offset, mX_gather, mD_tensormap, mY1_tensormap, mE_permute_order, stream
     ):
+        if const_expr(self.is_concatenated_gate_up):
+            half_N = mW1.shape[0] // 2
+            mW1 = cute.make_tensor(
+                mW1.iterator,
+                cute.make_layout(
+                    ((2, half_N), mW1.shape[1], mW1.shape[2]),
+                    stride=((half_N * mW1.stride[0], mW1.stride[0]), mW1.stride[1], mW1.stride[2]),
+                ),
+            )
         return self.module(
             mX,
             mW1,
@@ -424,7 +434,8 @@ class HopperWgmma_MoE_Down_proj_WeightGrad_Bwd:
 
 
 class HopperWgmma_MoE_Up_proj_ActGrad_Bwd:
-    def __init__(self, E: int, H: int, I: int, is_glu_activation: bool):
+    def __init__(self, E: int, H: int, I: int, is_glu_activation: bool, is_concatenated_gate_up: bool = False):
+        self.is_concatenated_gate_up = is_concatenated_gate_up
         super().__init__()
         if is_glu_activation:
             assert (
@@ -478,6 +489,15 @@ class HopperWgmma_MoE_Up_proj_ActGrad_Bwd:
     def __call__(
         self, mDz, mW1_trans, mDx_expanded, mE_offset, mX_gather, mS_scatter, tensormaps, mE_permute_order, stream
     ):
+        if const_expr(self.is_concatenated_gate_up):
+            half_N = mW1_trans.shape[1] // 2
+            mW1_trans = cute.make_tensor(
+                mW1_trans.iterator,
+                cute.make_layout(
+                    (mW1_trans.shape[0], (2, half_N), mW1_trans.shape[2]),
+                    stride=(mW1_trans.stride[0], (half_N * mW1_trans.stride[1], mW1_trans.stride[1]), mW1_trans.stride[2]),
+                ),
+            )
         return self.module(
             mDz,
             mW1_trans,
@@ -504,7 +524,8 @@ class HopperWgmma_MoE_Up_proj_ActGrad_Bwd:
 
 
 class HopperWgmma_MoE_Up_proj_WeightGrad_Bwd:
-    def __init__(self, E: int, H: int, I: int, is_glu_activation: bool):
+    def __init__(self, E: int, H: int, I: int, is_glu_activation: bool, is_concatenated_gate_up: bool = False):
+        self.is_concatenated_gate_up = is_concatenated_gate_up
         super().__init__()
         if is_glu_activation:
             assert (
@@ -556,6 +577,15 @@ class HopperWgmma_MoE_Up_proj_WeightGrad_Bwd:
 
     @cute.jit
     def __call__(self, mX_trans, mDz_trans, mDw1_trans, mE_offset, mX_gather, tensormaps, mE_permute_order, stream):
+        if const_expr(self.is_concatenated_gate_up):
+            half_N = mDw1_trans.shape[1] // 2
+            mDw1_trans = cute.make_tensor(
+                mDw1_trans.iterator,
+                cute.make_layout(
+                    (mDw1_trans.shape[0], (2, half_N), mDw1_trans.shape[2]),
+                    stride=(mDw1_trans.stride[0], (half_N * mDw1_trans.stride[1], mDw1_trans.stride[1]), mDw1_trans.stride[2]),
+                ),
+            )
         return self.module(
             mX_trans,
             mDz_trans,

--- a/tests/moe_test.py
+++ b/tests/moe_test.py
@@ -5,7 +5,7 @@
 import torch
 from parameterized import parameterized
 
-from sonicmoe import KernelBackendMoE, MoE, enable_quack_gemm
+from sonicmoe import KernelBackendMoE, MoE, enable_quack_gemm, moe_general_routing_inputs
 from sonicmoe.enums import ActivationType
 
 from .test_commons import TestCommons
@@ -121,4 +121,100 @@ class MoETest(TestCommons):
                 w.grad = None
 
         torch_grads = kernel_grads = None
+        torch.cuda.empty_cache()
+
+
+class ConcatenatedGateUpTest(TestCommons):
+    """Tests for is_concatenated_gate_up: verify concatenated layout matches interleaved (used as reference)."""
+
+    @staticmethod
+    def _make_weights(E, I, H, device, dtype):
+        """Create interleaved (reference) and concatenated weight pairs."""
+        w1_inter = torch.randn(E, 2 * I, H, device=device, dtype=dtype).permute(1, 2, 0)
+        gate = w1_inter[0::2].permute(2, 0, 1)
+        up = w1_inter[1::2].permute(2, 0, 1)
+        w1_concat = torch.cat([gate, up], dim=1).contiguous().permute(1, 2, 0)
+        w2 = torch.randn(E, H, I, device=device, dtype=dtype).permute(1, 2, 0)
+        return w1_inter, w1_concat, w2
+
+    @staticmethod
+    def _make_routing(T, E, K, device):
+        topk_indices = torch.randint(0, E, (T, K), device=device)
+        topk_weights = torch.randn(T, K, device=device, dtype=torch.bfloat16).softmax(dim=-1)
+        token_idx = torch.arange(T, device=device, dtype=torch.int32).unsqueeze(1).expand(-1, K).reshape(-1)
+        expert_ids = topk_indices.reshape(-1).to(torch.int32)
+        router_scores = topk_weights.reshape(-1).to(torch.bfloat16)
+        return token_idx, expert_ids, router_scores
+
+    @parameterized.expand(
+        TestCommons.make_args_matrix(
+            [torch.device("cuda")],
+            [torch.bfloat16],
+            [
+                (8192, 768, 256, 128, 8),
+                (8192, 768, 512, 64, 4),
+                (8192, 4096, 512, 128, 8),
+                (8192, 4096, 1024, 64, 4),
+            ],
+            [ActivationType.SWIGLU, ActivationType.GEGLU, ActivationType.REGLU],
+            [False, True],  # add_bias
+        )
+    )
+    def test_concatenated_gate_up(
+        self,
+        device: torch.device,
+        dtype: torch.dtype,
+        problem_shape: tuple[int, int, int, int, int],
+        activation_type: ActivationType,
+        add_bias: bool,
+    ) -> None:
+        self.set_seed(_SEED)
+
+        T, H, I, E, K = problem_shape
+        w1_inter, w1_concat, w2 = self._make_weights(E, I, H, device, dtype)
+        b1 = torch.randn(E, 2 * I, device=device, dtype=dtype) if add_bias else None
+        b2 = torch.randn(E, H, device=device, dtype=dtype) if add_bias else None
+
+        x_ref = 0.02 * torch.randn(T, H, device=device, dtype=dtype, requires_grad=True)
+        x_test = x_ref.clone().detach().requires_grad_()
+        w1_inter_p = w1_inter.clone().detach().requires_grad_()
+        w1_concat_p = w1_concat.clone().detach().requires_grad_()
+
+        token_idx, expert_ids, router_scores = self._make_routing(T, E, K, device)
+        stream_id = torch.cuda.current_stream(device).cuda_stream
+
+        with torch.autocast(device.type, torch.float32):
+            out_ref, _ = moe_general_routing_inputs(
+                x_ref, router_scores, token_idx, expert_ids,
+                w1_inter_p, b1, w2, b2,
+                E, stream_id, activation_type,
+                is_inference_mode_enabled=False, is_concatenated_gate_up=False,
+            )
+            out_test, _ = moe_general_routing_inputs(
+                x_test, router_scores, token_idx, expert_ids,
+                w1_concat_p, b1, w2, b2,
+                E, stream_id, activation_type,
+                is_inference_mode_enabled=False, is_concatenated_gate_up=True,
+            )
+
+            self.assertTrue(torch.equal(out_ref, out_test),
+                            f"fwd max_diff={(out_ref - out_test).abs().max().item()}")
+
+        # Backward
+        dy = 0.02 * torch.randn(T, H, device=device, dtype=dtype)
+        grads_ref = torch.autograd.grad(out_ref, [x_ref, w1_inter_p], grad_outputs=dy)
+        grads_test = torch.autograd.grad(out_test, [x_test, w1_concat_p], grad_outputs=dy)
+
+        # dx
+        self.assertTrue(torch.equal(grads_ref[0], grads_test[0]),
+                        f"dx max_diff={(grads_ref[0] - grads_test[0]).abs().max().item()}")
+
+        # dw1: convert interleaved grad to concatenated layout for comparison
+        dw1_i = grads_ref[1]
+        gate_grad = dw1_i[0::2].permute(2, 0, 1)
+        up_grad = dw1_i[1::2].permute(2, 0, 1)
+        dw1_as_concat = torch.cat([gate_grad, up_grad], dim=1).contiguous().permute(1, 2, 0)
+        self.assertTrue(torch.equal(dw1_as_concat, grads_test[1]),
+                        f"dw1 max_diff={(dw1_as_concat - grads_test[1]).abs().max().item()}")
+
         torch.cuda.empty_cache()


### PR DESCRIPTION
We wanna add sonic-moe support in Transformers, but the experts layout we are using in our modeling across MoEs is concatenated [gate;up] and not the interleaved one (see #45) changing the weight layout to interleaved breaks a couple things for us and seems to be an adoption pain point in other projects as well so we are suggesting this PR 🤗

<img width="2400" height="1800" alt="bf16_experts_tflops" src="https://github.com/user-attachments/assets/e0063c48-1017-4027-837d-4afbc0143a9c" />
