### PR TITLE
Add support for concat layout of gated activation (SwiGLU)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Copyright (c) 2025, Wentao Guo, Mayank Mishra, Xinle Cheng, Ion Stoica, Tri Dao
 
 ## News
 
+- 04/19/2026: added `concat_layout` support for concatenated `[gate; up]` weight format. Compatible with HuggingFace Transformers.
 - 04/19/2026: we release SonicMoE with Blackwell (SM100) support, built on [QuACK](https://github.com/Dao-AILab/quack)'s Grouped GEMM kernels. 
 
 ## 📦 Installation
@@ -93,6 +94,33 @@ python benchmarks/moe-cute.py --thiek 32768,4096,1024,128,8 --topk_over_softmax 
 - SonicMoE with token rounding routing (SwiGLU activation)
 ```bash
 python benchmarks/moe-token-rounding.py --routing nr --thiekq 16384,4096,1024,256,8,128
+```
+
+#### Concatenated weight layout format
+
+By default, SonicMoE expects `w1` (the gated up-projection weight) in **interleaved** format: `[gate_0, up_0, gate_1, up_1, ...]`. HuggingFace models (Qwen3, Mixtral, DeepSeek, etc.) store `gate_up_proj` in **concatenated** format: `[gate_0, gate_1, ..., gate_{I-1}, up_0, up_1, ..., up_{I-1}]`.
+
+The `--concat_layout` flag lets SonicMoE consume the HuggingFace-native format directly and as *identical* speed since the QuACK GEMM kernel reinterprets the layout at the TMA descriptor level.
+
+```bash
+# Concat layout with TC top-K routing
+python benchmarks/moe-cute.py --thiek 32768,4096,1024,128,8 --concat_layout
+```
+
+This is an example usage:
+
+```python
+from sonicmoe.functional import moe_TC_softmax_topk_layer
+
+output, router_logits, expert_freq = moe_TC_softmax_topk_layer(
+    x, router_weight,
+    w1,              # concat [gate; up] format
+    b1,              
+    w2, b2, K,
+    stream_id=None,
+    activation_type="swiglu",
+    concat_layout=True,
+)
 ```
 
 ## 🤝 Contributing

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Copyright (c) 2025, Wentao Guo, Mayank Mishra, Xinle Cheng, Ion Stoica, Tri Dao
 
 ## News
 
-- 04/19/2026: added `concat_layout` support for concatenated `[gate; up]` weight format. Compatible with HuggingFace Transformers.
 - 04/19/2026: we release SonicMoE with Blackwell (SM100) support, built on [QuACK](https://github.com/Dao-AILab/quack)'s Grouped GEMM kernels. 
 
 ## 📦 Installation
@@ -81,47 +80,30 @@ make test
 
 ### Example usage
 
-- SonicMoE with TC top-K routing (softmax-over-topk, or `softmax(topk(logits))`)
-```bash
-python benchmarks/moe-cute.py --thiek 32768,4096,1024,128,8 --activation swiglu
-```
+- SonicMoE with TC top-K routing (softmax-over-topk, or `softmax(topk(logits))`) and interleaved weight layout format for up-proj weights
+    ```bash
+    python benchmarks/moe-cute.py --thiek 32768,4096,1024,128,8 --activation swiglu
+    ```
 
-- SonicMoE with Qwen3-style routing (topk-over-softmax, or `topk(softmax(logits))`) with topk probabilities renormalization
-```bash
-python benchmarks/moe-cute.py --thiek 32768,4096,1024,128,8 --topk_over_softmax --norm_topk_probs
-```
+- SonicMoE with Qwen3-style routing (topk-over-softmax, or `topk(softmax(logits))`) with topk probabilities renormalization and interleaved weight layout format for up-proj weights
+    ```bash
+    python benchmarks/moe-cute.py --thiek 32768,4096,1024,128,8 --topk_over_softmax --norm_topk_probs
+    ```
 
-- SonicMoE with token rounding routing (SwiGLU activation)
-```bash
-python benchmarks/moe-token-rounding.py --routing nr --thiekq 16384,4096,1024,256,8,128
-```
+- SonicMoE with token rounding routing (SwiGLU activation) and interleaved weight layout format for up-proj weights
+    ```bash
+    python benchmarks/moe-token-rounding.py --routing nr --thiekq 16384,4096,1024,256,8,128
+    ```
 
-#### Concatenated weight layout format
+- SonicMoE with concatenated weight layout format for up-proj weights
 
-By default, SonicMoE expects `w1` (the gated up-projection weight) in **interleaved** format: `[gate_0, up_0, gate_1, up_1, ...]`. HuggingFace models (Qwen3, Mixtral, DeepSeek, etc.) store `gate_up_proj` in **concatenated** format: `[gate_0, gate_1, ..., gate_{I-1}, up_0, up_1, ..., up_{I-1}]`.
+    By default, SonicMoE expects `w1` (the gated up-projection weights) in **interleaved** format: `[gate_0, up_0, gate_1, up_1, ...]`. HuggingFace models (Qwen3, Mixtral, DeepSeek, etc.) store `gate_up_proj` in **concatenated** format: `[gate_0, gate_1, ..., gate_{I-1}, up_0, up_1, ..., up_{I-1}]`.
 
-The `--concat_layout` flag lets SonicMoE consume the HuggingFace-native format directly and as *identical* speed since the QuACK GEMM kernel reinterprets the layout at the TMA descriptor level.
+    ```bash
+    # Concatenated weight layout format with TC top-K routing
+    python benchmarks/moe-cute.py --thiek 32768,4096,1024,128,8 --concat_layout
+    ```
 
-```bash
-# Concat layout with TC top-K routing
-python benchmarks/moe-cute.py --thiek 32768,4096,1024,128,8 --concat_layout
-```
-
-This is an example usage:
-
-```python
-from sonicmoe.functional import moe_TC_softmax_topk_layer
-
-output, router_logits, expert_freq = moe_TC_softmax_topk_layer(
-    x, router_weight,
-    w1,              # concat [gate; up] format
-    b1,              
-    w2, b2, K,
-    stream_id=None,
-    activation_type="swiglu",
-    concat_layout=True,
-)
-```
 
 ## 🤝 Contributing
 

--- a/benchmarks/moe-cute.py
+++ b/benchmarks/moe-cute.py
@@ -77,15 +77,21 @@ gemm_dgated_tuned.configs = [AutotuneConfig(config=c) for c in _gc.get_all_confi
 # ─────────────── Monkey-patch ends ───────────────
 
 
-def swiglu(x: torch.Tensor) -> torch.Tensor:
-    u = x[..., 1::2]
-    g = x[..., ::2]
+def swiglu(x: torch.Tensor, concat_layout: bool = False) -> torch.Tensor:
+    if concat_layout:
+        I = x.shape[-1] // 2
+        g, u = x[..., :I], x[..., I:]
+    else:
+        u, g = x[..., 1::2], x[..., ::2]
     return u * F.silu(g)
 
 
-def geglu(x: torch.Tensor) -> torch.Tensor:
-    u = x[..., 1::2]
-    g = x[..., ::2]
+def geglu(x: torch.Tensor, concat_layout: bool = False) -> torch.Tensor:
+    if concat_layout:
+        I = x.shape[-1] // 2
+        g, u = x[..., :I], x[..., I:]
+    else:
+        u, g = x[..., 1::2], x[..., ::2]
     return F.gelu(g.float()).to(dtype=g.dtype) * u
 
 
@@ -93,9 +99,12 @@ def gelu(x: torch.Tensor) -> torch.Tensor:
     return F.gelu(x.float()).to(dtype=x.dtype)
 
 
-def reglu(x: torch.Tensor) -> torch.Tensor:
-    u = x[..., 1::2]
-    g = x[..., ::2]
+def reglu(x: torch.Tensor, concat_layout: bool = False) -> torch.Tensor:
+    if concat_layout:
+        I = x.shape[-1] // 2
+        g, u = x[..., :I], x[..., I:]
+    else:
+        u, g = x[..., 1::2], x[..., ::2]
     return (F.relu(g.float()) * u).to(dtype=g.dtype)
 
 
@@ -157,6 +166,12 @@ def parse_arguments() -> argparse.Namespace:
         default=False,
         help="Renormalize topk probs to sum to 1 (only for softmax-then-topk)",
     )
+    parser.add_argument(
+        "--concat_layout",
+        action="store_true",
+        default=False,
+        help="Use concat [gate; up] weight layout instead of interleaved",
+    )
     args = parser.parse_args()
 
     if len(args.thiek) != 5:
@@ -180,6 +195,7 @@ def run(
     activation: Type[str],
     is_softmax_over_topk: bool = True,
     norm_topk_probs: bool = False,
+    concat_layout: bool = False,
     **kwargs,
 ):
     torch_dtype = {cutlass.BFloat16: torch.bfloat16, cutlass.Float16: torch.float16}[dtype]
@@ -189,7 +205,8 @@ def run(
     T, H, I, E, K = thiek
     TK = T * K
     routing_mode = "softmax_over_topk" if is_softmax_over_topk else f"topk_over_softmax (norm={norm_topk_probs})"
-    print(f"T {T}, I {I}, H {H}, E {E}, K {K}, routing: {routing_mode}")
+    layout_mode = "concat [gate; up]" if concat_layout else "interleaved [g0, u0, g1, u1, ...]"
+    print(f"T {T}, I {I}, H {H}, E {E}, K {K}, routing: {routing_mode}, w1 layout: {layout_mode}")
 
     random.seed(1111)
     torch.manual_seed(1111)
@@ -233,6 +250,7 @@ def run(
             activation,
             is_softmax_over_topk=is_softmax_over_topk,
             norm_topk_probs=norm_topk_probs,
+            concat_layout=concat_layout,
         )
         if add_bias:
             dx, dw1, db1, dw2, db2, drouter_w = torch.autograd.grad(
@@ -277,7 +295,7 @@ def run(
 
                 if T_idx.numel() > 0:
                     w1_out = F.linear(x[T_idx, :], w1[i, :, :].squeeze(), bias=(b1[i] if add_bias else None))
-                    w1_out = act_func(w1_out)
+                    w1_out = act_func(w1_out, concat_layout=concat_layout) if is_glu(activation) else act_func(w1_out)
 
                     w2_out = F.linear(w1_out, w2[i, :, :].squeeze(), bias=(b2[i] if add_bias else None))
 
@@ -342,6 +360,7 @@ def run(
         True,
         is_softmax_over_topk=is_softmax_over_topk,
         norm_topk_probs=norm_topk_probs,
+        concat_layout=concat_layout,
     )
 
     cuda_graph = torch.cuda.CUDAGraph()
@@ -364,6 +383,7 @@ def run(
                 True,
                 is_softmax_over_topk=is_softmax_over_topk,
                 norm_topk_probs=norm_topk_probs,
+                concat_layout=concat_layout,
             )
 
     fwd_timing = do_bench(lambda: cuda_graph.replay(), warmup=warmup, rep=repeats)
@@ -388,6 +408,7 @@ def run(
             True,
             is_softmax_over_topk=is_softmax_over_topk,
             norm_topk_probs=norm_topk_probs,
+            concat_layout=concat_layout,
         )
         return o
 
@@ -411,6 +432,7 @@ def run(
             False,
             is_softmax_over_topk=is_softmax_over_topk,
             norm_topk_probs=norm_topk_probs,
+            concat_layout=concat_layout,
         )
         return o
 
@@ -444,6 +466,7 @@ def run(
             False,
             is_softmax_over_topk=is_softmax_over_topk,
             norm_topk_probs=norm_topk_probs,
+            concat_layout=concat_layout,
         )
         o.backward(dout, retain_graph=True)
         x.grad = w1.grad = w2.grad = router_w.grad = None
@@ -472,5 +495,6 @@ if __name__ == "__main__":
         args.activation,
         is_softmax_over_topk=(not args.topk_over_softmax),
         norm_topk_probs=args.norm_topk_probs,
+        concat_layout=args.concat_layout,
     )
     print("PASS")

--- a/benchmarks/moe-cute.py
+++ b/benchmarks/moe-cute.py
@@ -77,21 +77,19 @@ gemm_dgated_tuned.configs = [AutotuneConfig(config=c) for c in _gc.get_all_confi
 # ─────────────── Monkey-patch ends ───────────────
 
 
-def swiglu(x: torch.Tensor, concat_layout: bool = False) -> torch.Tensor:
+def swiglu(h: torch.Tensor, concat_layout: bool = False) -> torch.Tensor:
     if concat_layout:
-        I = x.shape[-1] // 2
-        g, u = x[..., :I], x[..., I:]
+        g, u = torch.chunk(h, 2, dim=-1)
     else:
-        u, g = x[..., 1::2], x[..., ::2]
+        u, g = h[..., 1::2], h[..., ::2]
     return u * F.silu(g)
 
 
-def geglu(x: torch.Tensor, concat_layout: bool = False) -> torch.Tensor:
+def geglu(h: torch.Tensor, concat_layout: bool = False) -> torch.Tensor:
     if concat_layout:
-        I = x.shape[-1] // 2
-        g, u = x[..., :I], x[..., I:]
+        g, u = torch.chunk(h, 2, dim=-1)
     else:
-        u, g = x[..., 1::2], x[..., ::2]
+        u, g = h[..., 1::2], h[..., ::2]
     return F.gelu(g.float()).to(dtype=g.dtype) * u
 
 
@@ -99,12 +97,11 @@ def gelu(x: torch.Tensor) -> torch.Tensor:
     return F.gelu(x.float()).to(dtype=x.dtype)
 
 
-def reglu(x: torch.Tensor, concat_layout: bool = False) -> torch.Tensor:
+def reglu(h: torch.Tensor, concat_layout: bool = False) -> torch.Tensor:
     if concat_layout:
-        I = x.shape[-1] // 2
-        g, u = x[..., :I], x[..., I:]
+        g, u = torch.chunk(h, 2, dim=-1)
     else:
-        u, g = x[..., 1::2], x[..., ::2]
+        u, g = h[..., 1::2], h[..., ::2]
     return (F.relu(g.float()) * u).to(dtype=g.dtype)
 
 

--- a/benchmarks/moe-token-rounding.py
+++ b/benchmarks/moe-token-rounding.py
@@ -156,8 +156,8 @@ def ref_moe_token_rounding(
 
             w1_out = F.linear(x[T_idx, :], w1[i, :, :].squeeze(), bias=(b1[i] if b1 is not None else None))
             if concat_layout:
-                I = w1_out.shape[-1] // 2
-                w1_out = F.silu(w1_out[:, :I]) * w1_out[:, I:]
+                g, u = torch.chunk(w1_out, 2, dim=-1)
+                w1_out = F.silu(g) * u
             else:
                 w1_out = F.silu(w1_out[:, ::2]) * w1_out[:, 1::2]
 

--- a/benchmarks/moe-token-rounding.py
+++ b/benchmarks/moe-token-rounding.py
@@ -142,6 +142,7 @@ def ref_moe_token_rounding(
     w2: torch.Tensor,
     b2: torch.Tensor | None,
     E,
+    concat_layout: bool = False,
 ):
     T, D = x.shape  # # B, L, # total expert
 
@@ -154,7 +155,11 @@ def ref_moe_token_rounding(
         if T_idx.numel() > 0:
 
             w1_out = F.linear(x[T_idx, :], w1[i, :, :].squeeze(), bias=(b1[i] if b1 is not None else None))
-            w1_out = F.silu(w1_out[:, ::2]) * w1_out[:, 1::2]
+            if concat_layout:
+                I = w1_out.shape[-1] // 2
+                w1_out = F.silu(w1_out[:, :I]) * w1_out[:, I:]
+            else:
+                w1_out = F.silu(w1_out[:, ::2]) * w1_out[:, 1::2]
 
             w2_out = F.linear(w1_out, w2[i, :, :].squeeze(), bias=(b2[i] if b2 is not None else None))
 
@@ -205,6 +210,12 @@ def parse_arguments() -> argparse.Namespace:
         action="store_true",
         default=False,
     )
+    parser.add_argument(
+        "--concat_layout",
+        action="store_true",
+        default=False,
+        help="Use concat [gate; up] weight layout instead of interleaved",
+    )
     args = parser.parse_args()
 
     if len(args.thiekq) != 6:
@@ -213,7 +224,9 @@ def parse_arguments() -> argparse.Namespace:
     return args
 
 
-def our_e2e_fwd_bwd_call(x, router_scores, token_indices, expert_indices, w1, b1, w2, b2, E, dout):
+def our_e2e_fwd_bwd_call(
+    x, router_scores, token_indices, expert_indices, w1, b1, w2, b2, E, dout, concat_layout=False
+):
     o, _ = moe_general_routing_inputs(
         x,
         router_scores,
@@ -227,12 +240,13 @@ def our_e2e_fwd_bwd_call(x, router_scores, token_indices, expert_indices, w1, b1
         None,
         ActivationType.SWIGLU,
         False,
+        concat_layout=concat_layout,
     )
     torch.autograd.grad(o, [x, router_scores, w1, w2], dout, retain_graph=True)
     router_scores.grad = x.grad = w1.grad = w2.grad = None
 
 
-def our_fwd_call(x, router_scores, token_indices, expert_indices, w1, b1, w2, b2, E):
+def our_fwd_call(x, router_scores, token_indices, expert_indices, w1, b1, w2, b2, E, concat_layout=False):
     return moe_general_routing_inputs(
         x,
         router_scores,
@@ -246,6 +260,7 @@ def our_fwd_call(x, router_scores, token_indices, expert_indices, w1, b1, w2, b2
         None,
         ActivationType.SWIGLU,
         False,
+        concat_layout=concat_layout,
     )
 
 
@@ -324,6 +339,7 @@ def run(
     routing: str,
     skip_test: Type[bool],
     add_bias: Type[bool],
+    concat_layout: bool = False,
     **kwargs,
 ):
 
@@ -400,6 +416,7 @@ def run(
             None,
             ActivationType.SWIGLU,
             False,
+            concat_layout=concat_layout,
         )
         if add_bias:
             dx, dw1, db1, dw2, db2, drouter_w = torch.autograd.grad(
@@ -418,6 +435,7 @@ def run(
             w2,
             b2,
             E,
+            concat_layout=concat_layout,
         )
         ref_expert_frequency = expert_indices.view(-1).bincount(minlength=E)
 
@@ -489,6 +507,7 @@ def run(
             b2,
             E,
             dout,
+            concat_layout=concat_layout,
         )
 
         TK = router_scores.shape[0]
@@ -504,6 +523,7 @@ def run(
                 w2.permute(1, 2, 0),
                 b2,
                 E,
+                concat_layout=concat_layout,
             ),
             warmup=10,
             rep=rep,
@@ -527,6 +547,7 @@ def run(
                 b2,
                 E,
                 dout,
+                concat_layout=concat_layout,
             ),
             warmup=10,
             rep=rep,
@@ -561,5 +582,13 @@ def run(
 
 if __name__ == "__main__":
     args = parse_arguments()
-    run(args.thiekq, args.dtype, args.rep, args.routing, args.skip_test, args.add_bias)
+    run(
+        args.thiekq,
+        args.dtype,
+        args.rep,
+        args.routing,
+        args.skip_test,
+        args.add_bias,
+        concat_layout=args.concat_layout,
+    )
     print("PASS")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.12"
 dependencies = [
     "nvidia-cutlass-dsl==4.4.2",
     "torch>=2.7.1,<=2.9.1",
-    "quack-kernels>=0.3.10",
+    "quack-kernels>=0.3.11",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "sonic-moe"
 dynamic = ["version"]
+readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "nvidia-cutlass-dsl==4.4.2",
@@ -13,7 +14,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-cu13 = ["nvidia-cutlass-dsl[cu13]>=4.4.0"]
+cu13 = ["nvidia-cutlass-dsl[cu13]>=4.4.2"]
 dev = [
     "pre-commit",
     "ruff",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 
 torch>=2.7.1,<=2.9.1
 nvidia-cutlass-dsl==4.4.2
-quack-kernels>=0.3.10
+quack-kernels>=0.3.11
 pytest
 parameterized
 rich

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 from setuptools import find_packages, setup
 
 
-VERSION = "0.0.1"
+VERSION = "0.1.2"
 
 setup(
     name="sonicmoe",

--- a/sonicmoe/functional/__init__.py
+++ b/sonicmoe/functional/__init__.py
@@ -91,6 +91,7 @@ class _UpProjection(torch.autograd.Function):
         is_each_token_has_variable_activated_experts: bool,
         activation_type: ActivationType,
         is_inference_mode_enabled: bool,
+        concat_layout: bool = False,
     ) -> torch.Tensor:
         T, H = x.shape
         I, H, E = w1.shape
@@ -116,6 +117,7 @@ class _UpProjection(torch.autograd.Function):
             x_gather_idx=x_gather_idx,
             activation_type=activation_type.value,
             is_inference_mode_enabled=is_inference_mode_enabled,
+            concat_layout=concat_layout,
         )
 
         ctx.T = T
@@ -126,6 +128,7 @@ class _UpProjection(torch.autograd.Function):
         ctx.I = I
         ctx.is_each_token_has_variable_activated_experts = is_each_token_has_variable_activated_experts
         ctx.is_glu_activation = is_glu_activation
+        ctx.concat_layout = concat_layout
 
         ctx.save_for_backward(
             x,
@@ -152,6 +155,7 @@ class _UpProjection(torch.autograd.Function):
         H = ctx.H
         is_glu_activation = ctx.is_glu_activation
         is_each_token_has_variable_activated_experts = ctx.is_each_token_has_variable_activated_experts
+        concat_layout = ctx.concat_layout
 
         (
             x,
@@ -175,6 +179,7 @@ class _UpProjection(torch.autograd.Function):
             db1=db1,
             expert_frequency_offset=expert_frequency_offset,
             is_glu_activation=is_glu_activation,
+            concat_layout=concat_layout,
         )
 
         _up_projection_backward_weight(
@@ -184,6 +189,7 @@ class _UpProjection(torch.autograd.Function):
             expert_frequency_offset=expert_frequency_offset,
             x_gather_idx=x_gather_idx,
             is_glu_activation=is_glu_activation,
+            concat_layout=concat_layout,
         )
 
         dx_reduced = torch.empty(T, H, dtype=dh.dtype, device=dh.device)
@@ -198,7 +204,7 @@ class _UpProjection(torch.autograd.Function):
             is_varlen_K=is_each_token_has_variable_activated_experts,
         )
 
-        return dx_reduced, dw1, db1, *[None] * 12
+        return dx_reduced, dw1, db1, *[None] * 13
 
 
 class _DownProjection(torch.autograd.Function):
@@ -335,6 +341,7 @@ def moe_TC_softmax_topk_layer(
     is_inference_mode_enabled: bool = False,
     is_softmax_over_topk: bool = True,
     norm_topk_probs: bool = False,
+    concat_layout: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     assert ((b1 is None) and (b2 is None)) or (
         (b1 is not None) and (b2 is not None)
@@ -379,6 +386,7 @@ def moe_TC_softmax_topk_layer(
         False,  # is_each_token_has_variable_activated_expert
         activation_type,
         is_inference_mode_enabled,
+        concat_layout,
     )
 
     o = _DownProjection.apply(
@@ -403,7 +411,9 @@ def moe_TC_softmax_topk_layer(
 
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # Weight format requirements:
-# - w1_weight: Shape (2*I, H, E), stride order (2, 0, 1), must be interleaved [gate_row0, up_row0, gate_row1, up_row1, ...]
+# - w1_weight: Shape (2*I, H, E), stride order (2, 0, 1)
+#     concat_layout=False (default): interleaved [gate_row0, up_row0, gate_row1, up_row1, ...]
+#     concat_layout=True:            concatenated [gate_row0, ..., gate_row_{I-1}, up_row0, ..., up_row_{I-1}]
 # - w2_weight: Shape (H, I, E), stride order (2, 0, 1)
 
 
@@ -423,6 +433,7 @@ def moe_general_routing_inputs(
     stream_id: int,
     activation_type: ActivationType,
     is_inference_mode_enabled: bool = False,
+    concat_layout: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     assert ((b1 is None) and (b2 is None)) or (
         (b1 is not None) and (b2 is not None)
@@ -473,6 +484,7 @@ def moe_general_routing_inputs(
         True,  # is_each_token_has_variable_activated_expert
         activation_type,
         is_inference_mode_enabled,
+        concat_layout,
     )
 
     o = _DownProjection.apply(

--- a/sonicmoe/functional/backward.py
+++ b/sonicmoe/functional/backward.py
@@ -126,28 +126,29 @@ def _prune_triton_autotune_config(configs, nargs, **kw):
 )
 @triton.jit
 def db1_kernel(
-    dz_ptr,  # (T, H)
-    db1_ptr,  # (E, H),
-    expert_offset_ptr,  # (E+1,), offsets in grouped layout
+    dh_ptr,  # (TK, I)  — always interleaved
+    db1_ptr,  # (E, I)
+    expert_offset_ptr,  # (E+1,)
     I: tl.constexpr,
     E: tl.constexpr,
-    BLOCK_I: tl.constexpr,  # Block size for H dimension
-    BLOCK_TK: tl.constexpr,  # Block size for token dimension
+    BLOCK_I: tl.constexpr,
+    BLOCK_TK: tl.constexpr,
+    CONCAT_LAYOUT: tl.constexpr = False,
 ):
-    Eidx = tl.program_id(0)  # expert id
+    Eidx = tl.program_id(0)
 
     E_count_start = tl.load(expert_offset_ptr + Eidx).to(tl.int64)
     E_count_end = tl.load(expert_offset_ptr + Eidx + 1).to(tl.int64)
     n_tokens = E_count_end - E_count_start
 
     NUM_I_BLOCKS: tl.constexpr = triton.cdiv(I, BLOCK_I)
+    I_HALF: tl.constexpr = I // 2
     for Iidx in tl.static_range(0, NUM_I_BLOCKS, 1):
         i_offsets = Iidx * BLOCK_I + tl.arange(0, BLOCK_I)
         i_mask = i_offsets < I
 
         db1_acc = tl.zeros([BLOCK_I], dtype=tl.float32)
 
-        # Process tokens in blocks of BLOCK_TK
         for block_start in tl.range(0, n_tokens, BLOCK_TK):
             # Token offsets within this block
             tk_offsets = block_start + tl.arange(0, BLOCK_TK)
@@ -156,11 +157,16 @@ def db1_kernel(
 
             dz_offsets = tk_grouped[:, None] * I + i_offsets[None, :]
             dz_mask = tk_mask[:, None] & i_mask[None, :]
-            dz = tl.load(dz_ptr + dz_offsets, mask=dz_mask, other=0.0).to(tl.float32)
+            dz = tl.load(dh_ptr + dz_offsets, mask=dz_mask, other=0.0).to(tl.float32)
 
-            db1_acc += tl.sum(dz, axis=0)  # Sum over BLOCK_TK dimension
+            db1_acc += tl.sum(dz, axis=0)
 
-        db1_offsets = Eidx.to(tl.int64) * I + i_offsets
+        # Write: remap interleaved → concat if needed
+        if CONCAT_LAYOUT:
+            out_offsets = i_offsets // 2 + (i_offsets % 2) * I_HALF
+        else:
+            out_offsets = i_offsets
+        db1_offsets = Eidx.to(tl.int64) * I + out_offsets
         tl.store(db1_ptr + db1_offsets, db1_acc, mask=i_mask)
 
 
@@ -172,16 +178,31 @@ def _up_projection_backward_act(
     db1: torch.Tensor | None,
     expert_frequency_offset: torch.Tensor,
     is_glu_activation: bool,
+    concat_layout: bool = False,
 ) -> None:
     I, H, E = w1.size()
     if is_glu_activation:
         I //= 2
 
-    gemm(dh, w1.permute(2, 0, 1), cu_seqlens_m=expert_frequency_offset, dynamic_scheduler=False, out=dx_expanded)
+    gemm(
+        dh,
+        w1.permute(2, 0, 1),
+        cu_seqlens_m=expert_frequency_offset,
+        dynamic_scheduler=False,
+        out=dx_expanded,
+        concat_layout=(("B",) if concat_layout else None),
+    )
 
     # db1 computation
     if db1 is not None:
-        db1_kernel[(E,)](dh, db1, expert_frequency_offset, (2 * I if is_glu_activation else I), E)
+        db1_kernel[(E,)](
+            dh,
+            db1,
+            expert_frequency_offset,
+            (2 * I if is_glu_activation else I),
+            E,
+            CONCAT_LAYOUT=concat_layout and is_glu_activation,
+        )
 
 
 _up_projection_backward_act.compile_cache = {}
@@ -195,6 +216,7 @@ def _up_projection_backward_weight(
     expert_frequency_offset: torch.Tensor,
     x_gather_idx: torch.Tensor,
     is_glu_activation: bool,
+    concat_layout: bool = False,
 ) -> None:
     I, H, E = dw1.size()
     if is_glu_activation:
@@ -208,6 +230,7 @@ def _up_projection_backward_weight(
         A_idx=x_gather_idx,
         batch_idx_permute=None,
         dynamic_scheduler=False,
+        concat_layout=(("out",) if concat_layout else None),
     )
 
 
@@ -377,11 +400,6 @@ def _softmax_over_topk_bwd_kernel(
     if not dlogits_is_none:
         add_vals += tl.load(dlogits_ptr + indices, mask=k_mask)
     tl.store(dlogits_full_ptr + indices, add_vals, mask=k_mask)
-
-
-# =============================================================================
-# Add this kernel BEFORE the existing _topk_softmax_bwd wrapper in backward.py
-# =============================================================================
 
 
 @triton.jit

--- a/sonicmoe/functional/forward.py
+++ b/sonicmoe/functional/forward.py
@@ -73,6 +73,7 @@ def _up_projection_forward(
     x_gather_idx: torch.Tensor,
     activation_type: str,
     is_inference_mode_enabled: bool = False,
+    concat_layout: bool = False,
 ) -> None:
     assert activation_type in (
         "swiglu",
@@ -88,6 +89,7 @@ def _up_projection_forward(
         postact_out=a,
         store_preact=(not is_inference_mode_enabled),
         bias=b1,
+        concat_layout=(("B",) if concat_layout else None),
     )
 
 

--- a/sonicmoe/functional/forward.py
+++ b/sonicmoe/functional/forward.py
@@ -89,7 +89,7 @@ def _up_projection_forward(
         postact_out=a,
         store_preact=(not is_inference_mode_enabled),
         bias=b1,
-        concat_layout=(("B",) if concat_layout else None),
+        concat_layout=(("B", "bias") if b1 is not None else ("B",)) if concat_layout else None,
     )
 
 


### PR DESCRIPTION
Related PR or issues: #12 #45 #46

`python benchmarks/moe-cute.py --concat_layout` provides an example of running the MoE forward pass where the gating and up-projection hidden states are concatenated.

Reference pytorch code for activation:
```
def swiglu(h: torch.Tensor, concat_layout: bool = False) -> torch.Tensor:
    if concat_layout:
        I = h.shape[-1] // 2
        g, u = h[..., :I], h[..., I:]
    else:
        u, g = h[..., 1::2], h[..., ::2]
    return u * F.silu(g)
```

Co-authored by @IlyasMoutawwakil