### PR TITLE
upgrade torch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,7 @@ Copyright (c) 2025, Wentao Guo, Mayank Mishra, Xinle Cheng, Ion Stoica, Tri Dao
 - NVIDIA Hopper GPUs (H100, H200, etc.), Blackwell datacenter GPUs (GB200, B200, B300, etc.), or Blackwell consumer GPUs (e.g. RTX 5090, SM120)
 - CUDA 12.9+ (13.0+ for B300 GPUs)
 - Python 3.12+ recommended
-- PyTorch 2.7+ (2.9.1 recommended)
-
-> **B300 users:** please manually upgrade Triton to 3.6.0 after installing PyTorch.
-
+- PyTorch 2.11+ (2.12 recommended)
 
 ### Install from pip
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "torch>=2.7.1,<=2.9.1",
+    "torch>=2.11.0",
     "quack-kernels>=0.4.0",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2025, Wentao Guo, Mayank Mishra, Xinle Cheng, Ion Stoica, Tri Dao
 # ********************************************************************************
 
-torch>=2.7.1,<=2.9.1
+torch>=2.11.0
 quack-kernels>=0.4.0
 pytest
 parameterized

--- a/sonicmoe/functional/__init__.py
+++ b/sonicmoe/functional/__init__.py
@@ -368,7 +368,6 @@ def moe_TC_softmax_topk_layer(
     if type(activation_type) == str:
         activation_type = ActivationType(activation_type)
 
-    assert not torch.compiler.is_compiling()
     assert is_glu(activation_type), "QuACK GEMM does not support non GLU activation yet"
 
     a, h = _UpProjection.apply(
@@ -466,7 +465,6 @@ def moe_general_routing_inputs(
         num_activated_expert_per_token_offset,
     )
 
-    assert not torch.compiler.is_compiling()
     assert is_glu(activation_type), "QuACK GEMM does not support non GLU activation yet"
 
     a, h = _UpProjection.apply(


### PR DESCRIPTION
Upgrade torch version to 2.11 and above, now there is no issue with `torch.compile` so we drop `assert not torch.compiler.is_compiling()`
I checked with `torch.compile` default and fullgraph.