### PR TITLE
[feat] Support non-gated activations (squared-ReLU / relu_sq)

### DIFF
--- a/sonicmoe/functional/__init__.py
+++ b/sonicmoe/functional/__init__.py
@@ -6,7 +6,7 @@ import os
 
 import torch
 import torch.nn.functional as F
-from quack.gemm_interface import gemm, gemm_dgated, gemm_gated
+from quack.gemm_interface import gemm, gemm_act, gemm_dgated, gemm_gated
 
 from ..enums import ActivationType, is_glu
 from .backward import (
@@ -105,22 +105,34 @@ class _UpProjection(torch.autograd.Function):
             else None
         )
 
-        assert activation_type.value in (
-            "swiglu",
-            "geglu",
-        ), f"QuACK gemm_gated only supports glu activations, got {activation_type.value}"
-        gemm_gated(
-            x,
-            w1.permute(2, 1, 0),
-            activation=activation_type.value,
-            cu_seqlens_m=expert_frequency_offset,
-            A_idx=x_gather_idx,
-            preact_out=h,
-            postact_out=a,
-            store_preact=(not is_inference_mode_enabled),
-            bias=b1,
-            concat_layout=(("B", "bias") if b1 is not None else ("B",)) if concat_layout else None,
-        )
+        if is_glu_activation:
+            gemm_gated(
+                x,
+                w1.permute(2, 1, 0),
+                activation=activation_type.value,
+                cu_seqlens_m=expert_frequency_offset,
+                A_idx=x_gather_idx,
+                preact_out=h,
+                postact_out=a,
+                store_preact=(not is_inference_mode_enabled),
+                bias=b1,
+                concat_layout=(("B", "bias") if b1 is not None else ("B",)) if concat_layout else None,
+            )
+        else:
+            # Non-gated fused activation GEMM (e.g. relu_sq / srelu). preact h and
+            # postact a are both (TK, I); ds is handled separately in the backward
+            # (gemm_dact has no colvec_reduce for non-gated activations).
+            gemm_act(
+                x,
+                w1.permute(2, 1, 0),
+                activation=activation_type.value,
+                cu_seqlens_m=expert_frequency_offset,
+                A_idx=x_gather_idx,
+                preact_out=h,
+                postact_out=a,
+                store_preact=(not is_inference_mode_enabled),
+                bias=b1,
+            )
 
         ctx.T = T
         ctx.TK = TK
@@ -368,7 +380,9 @@ def moe_TC_softmax_topk_layer(
     if type(activation_type) == str:
         activation_type = ActivationType(activation_type)
 
-    assert is_glu(activation_type), "QuACK GEMM does not support non GLU activation yet"
+    assert is_glu(activation_type) or activation_type == ActivationType.RELU_SQ, (
+        f"SonicMoE supports GLU activations and relu_sq; got {activation_type}"
+    )
 
     a, h = _UpProjection.apply(
         x,
@@ -465,7 +479,9 @@ def moe_general_routing_inputs(
         num_activated_expert_per_token_offset,
     )
 
-    assert is_glu(activation_type), "QuACK GEMM does not support non GLU activation yet"
+    assert is_glu(activation_type) or activation_type == ActivationType.RELU_SQ, (
+        f"SonicMoE supports GLU activations and relu_sq; got {activation_type}"
+    )
 
     a, h = _UpProjection.apply(
         x,

--- a/sonicmoe/functional/backward.py
+++ b/sonicmoe/functional/backward.py
@@ -170,6 +170,62 @@ def db1_kernel(
         tl.store(db1_ptr + db1_offsets, db1_acc, mask=i_mask)
 
 
+def _get_autotune_configs_for_relu_sq_down() -> list[triton.Config]:
+    configs = []
+    for BLOCK_TK in get_powers_of_2(1, 16):
+        configs.append(triton.Config({"BLOCK_TK": BLOCK_TK}, num_warps=4, num_stages=2))
+    return configs
+
+
+@triton.autotune(
+    configs=_get_autotune_configs_for_relu_sq_down(),
+    key=["I"],
+)
+@triton.jit
+def relu_sq_down_bwd_kernel(
+    da_ptr,  # (TK, I), grad wrt postact a (unscaled), grouped layout
+    h_ptr,  # (TK, I), preact, grouped layout
+    topk_scores_ptr,  # (TK,)
+    s_scatter_idx_ptr,  # (TK,), maps grouped -> scatter index
+    dh_ptr,  # (TK, I), out: grad wrt preact h (score-scaled)
+    ds_ptr,  # (TK,), out: grad wrt router score (scatter layout)
+    a_prime_ptr,  # (TK, I), out: score-scaled postact (for the dw2 gemm)
+    TK,
+    I: tl.constexpr,
+    BLOCK_I: tl.constexpr,
+    BLOCK_TK: tl.constexpr,
+):
+    # This is an elementwise + per-row reduction kernel (outputs are TK x I), so
+    # we tile over the grouped tokens for maximum parallelism — grid over the
+    # token dim (NOT over experts, unlike the db1/db2 reduction kernels).
+    pid = tl.program_id(0)
+    rows = pid * BLOCK_TK + tl.arange(0, BLOCK_TK)
+    row_mask = rows < TK
+    i_offsets = tl.arange(0, BLOCK_I)
+    i_mask = i_offsets < I
+
+    # Per-token router score (looked up through the scatter index).
+    scatter_idx = tl.load(s_scatter_idx_ptr + rows, mask=row_mask, other=0).to(tl.int64)
+    s = tl.load(topk_scores_ptr + scatter_idx, mask=row_mask, other=0.0).to(tl.float32)
+
+    # [BLOCK_TK, BLOCK_I] tiles of the preact and the unscaled postact grad.
+    offsets = rows[:, None] * I + i_offsets[None, :]
+    mask = row_mask[:, None] & i_mask[None, :]
+    h = tl.load(h_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    da = tl.load(da_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+
+    # relu_sq(h) = relu(h) * h ; d/dh relu_sq(h) = 2 * relu(h).
+    relu_h = tl.maximum(h, 0.0)
+    a = relu_h * h
+
+    # a_prime = s * relu_sq(h)  — scaled postact consumed by the dw2 gemm.
+    tl.store(a_prime_ptr + offsets, a * s[:, None], mask=mask)
+    # dh = s * da * 2*relu(h)   — grad wrt the pre-activation.
+    tl.store(dh_ptr + offsets, da * (2.0 * relu_h) * s[:, None], mask=mask)
+    # ds = <relu_sq(h), da>     — router-score grad (unscaled), scatter layout.
+    tl.store(ds_ptr + scatter_idx, tl.sum(a * da, axis=1), mask=row_mask)
+
+
 @torch.library.custom_op(f"{LIBRARY_NAME}::_up_projection_backward_act", mutates_args={"dx_expanded", "db1"})
 def _up_projection_backward_act(
     w1: torch.Tensor,
@@ -224,6 +280,36 @@ def _down_projection_backward_act(
     s_scatter_idx: torch.Tensor,
     activation_type: str,
 ) -> None:
+    if activation_type == "relu_sq":
+        assert b2 is None and db2 is None, "relu_sq SonicMoE backward does not support down-projection bias"
+        I = w2.size(1)
+        TK = x_gather_idx.size(0)
+        # da = dout (gathered per token) @ w2 — grad wrt the postact, unscaled.
+        da = torch.empty_like(h)
+        gemm(
+            dout,
+            w2.permute(2, 0, 1),
+            cu_seqlens_m=expert_frequency_offset,
+            A_idx=x_gather_idx,
+            dynamic_scheduler=False,
+            out=da,
+        )
+        # Fuse the activation backward, router-score grad and dw2-input scaling.
+        grid = lambda meta: (triton.cdiv(TK, meta["BLOCK_TK"]),)
+        relu_sq_down_bwd_kernel[grid](
+            da,
+            h,
+            topk_scores,
+            s_scatter_idx,
+            dh,
+            ds,
+            a_prime,
+            TK,
+            I,
+            BLOCK_I=triton.next_power_of_2(I),
+        )
+        return
+
     assert activation_type in (
         "swiglu",
         "geglu",


### PR DESCRIPTION
## Motivation

SonicMoE's fused expert path is currently GLU-only — `_UpProjection` and the
`general_routing` / `TC_softmax_topk` entry points `assert is_glu(activation_type)`.
We're integrating SonicMoE as the routed-expert backend of a protein-LM
pretraining stack whose experts use **squared-ReLU** (`relu_sq`, non-gated), and
hit that assert.

Switching that one MoE block from a CUTLASS grouped-GEMM path to SonicMoE took
**24% → 29% H100 MFU** (~+21% relative) on a 1-node 4×H100 run, and — importantly
— **stays sync-free in both fwd and bwd** (no host/D2H sync; CUDA-graph
capturable), which is the property that made SonicMoE attractive over the
alternatives since our protein models are small and are trained on GraceHopper superchips where the single thread cpu performance is not great.

This PR adds non-gated `relu_sq` support without touching the GLU path.

## What this changes

**Forward (`functional/__init__.py`)**
- `_UpProjection.forward`: for non-GLU, use `quack.gemm_interface.gemm_act(activation="relu_sq", ...)` instead of `gemm_gated` (same `cu_seqlens_m` + `A_idx` fusion; preact `h` and postact `a` are both `(TK, I)`).
- Relax the two `is_glu` asserts in `moe_TC_softmax_topk_layer` / `moe_general_routing_inputs` to also allow `ActivationType.RELU_SQ`.

**Backward (`functional/backward.py`)**
- The GLU path fuses the router-score gradient `ds` via `gemm_dgated`'s `colvec_scale`/`colvec_reduce`. For non-gated activations `gemm_dact` does not support `colvec_*`, so `_down_projection_backward_act` gets a non-gated branch that computes the pieces explicitly with one `gemm` + one fused Triton kernel (`relu_sq_down_bwd_kernel`):
  - `da = gather(dout) @ w2`  (grad wrt the postact, unscaled)
  - `a = relu_sq(h)`;  `ds = <a, da>`  (router-score grad)
  - `dh = s · da · 2·relu(h)`  (grad wrt the pre-activation)
  - `a_prime = s · a`  (score-scaled postact, so the existing `dw2` gemm is unchanged)
- `_up_projection_backward_act` already parameterizes the intermediate dim, so it handles the non-gated `I` (vs `2I`) as-is.
- `relu_sq_down_bwd_kernel` is autotuned over `BLOCK_TK` and grids over the token dim — it's elementwise plus a per-row reduction, so it parallelizes over tokens rather than using the per-expert grid of the db1/db2 reduction kernels.

## Validation

Checked against a pure-torch reference MoE (same router decisions + weights), bf16, on H100:
- forward: rel max-err ≈ **5e-3**
- backward gradcheck (`dx`, `dW1`, `dW2`, router grad): rel max-err **< 8e-3**

## Notes / limitations

- GLU path is untouched; this is purely additive and opt-in via `activation_function`.
- `relu_sq` down-projection **bias** is not supported (asserted) — happy to add if useful.
- Validation above used our integration harness, not `tests/moe_test.py` yet. I'd be glad to **add a `relu_sq` case to `tests/moe_test.py`** (parametrize `activation_function`, skip the bias combo), and to rebase/adjust if this conflicts with any in-flight refactor — just let me know your preference.

Thanks for the great library — the IO-aware fused backward is exactly what we needed.
