### PR TITLE
[feat] Support non-gated activations through unified QuACK APIs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,11 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "torch>=2.11.0",
-    "quack-kernels>=0.4.0",
+    "quack-kernels>=0.6.4",
 ]
 
 [project.optional-dependencies]
-cu13 = ["quack-kernels[cu13]>=0.4.0"]
+cu13 = ["quack-kernels[cu13]>=0.6.4"]
 dev = [
     "pre-commit",
     "ruff",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # ********************************************************************************
 
 torch>=2.11.0
-quack-kernels>=0.4.0
+quack-kernels>=0.6.4
 pytest
 parameterized
 rich

--- a/sonicmoe/functional/__init__.py
+++ b/sonicmoe/functional/__init__.py
@@ -6,7 +6,7 @@ import os
 
 import torch
 import torch.nn.functional as F
-from quack.gemm_interface import gemm, gemm_dgated, gemm_gated
+from quack.gemm_interface import gemm, gemm_act
 
 from ..enums import ActivationType, is_glu
 from .backward import (
@@ -105,11 +105,7 @@ class _UpProjection(torch.autograd.Function):
             else None
         )
 
-        assert activation_type.value in (
-            "swiglu",
-            "geglu",
-        ), f"QuACK gemm_gated only supports glu activations, got {activation_type.value}"
-        gemm_gated(
+        gemm_act(
             x,
             w1.permute(2, 1, 0),
             activation=activation_type.value,
@@ -119,7 +115,11 @@ class _UpProjection(torch.autograd.Function):
             postact_out=a,
             store_preact=(not is_inference_mode_enabled),
             bias=b1,
-            concat_layout=(("B", "bias") if b1 is not None else ("B",)) if concat_layout else None,
+            concat_layout=(
+                (("B", "bias") if b1 is not None else ("B",))
+                if concat_layout and is_glu_activation
+                else None
+            ),
         )
 
         ctx.T = T
@@ -130,7 +130,7 @@ class _UpProjection(torch.autograd.Function):
         ctx.I = I
         ctx.is_each_token_has_variable_activated_experts = is_each_token_has_variable_activated_experts
         ctx.is_glu_activation = is_glu_activation
-        ctx.concat_layout = concat_layout
+        ctx.concat_layout = concat_layout and is_glu_activation
 
         ctx.save_for_backward(
             x,
@@ -368,8 +368,6 @@ def moe_TC_softmax_topk_layer(
     if type(activation_type) == str:
         activation_type = ActivationType(activation_type)
 
-    assert is_glu(activation_type), "QuACK GEMM does not support non GLU activation yet"
-
     a, h = _UpProjection.apply(
         x,
         w1,
@@ -464,8 +462,6 @@ def moe_general_routing_inputs(
         s_reverse_scatter_idx,
         num_activated_expert_per_token_offset,
     )
-
-    assert is_glu(activation_type), "QuACK GEMM does not support non GLU activation yet"
 
     a, h = _UpProjection.apply(
         x,

--- a/sonicmoe/functional/backward.py
+++ b/sonicmoe/functional/backward.py
@@ -9,7 +9,7 @@ import cutlass.cute as cute
 import torch
 import triton
 import triton.language as tl
-from quack.gemm_interface import gemm, gemm_dgated
+from quack.gemm_interface import gemm, gemm_dact
 
 from ..enums import LIBRARY_NAME
 from ..utils import get_powers_of_2
@@ -224,13 +224,8 @@ def _down_projection_backward_act(
     s_scatter_idx: torch.Tensor,
     activation_type: str,
 ) -> None:
-    assert activation_type in (
-        "swiglu",
-        "geglu",
-    ), f"QuACK gemm_gated only supports glu activations, got {activation_type}"
-
     s = topk_scores[s_scatter_idx]
-    _, _, ds_scattered = gemm_dgated(
+    _, _, ds_scattered = gemm_dact(
         dout,
         w2.permute(2, 0, 1),
         PreAct=h,

--- a/tests/moe_test.py
+++ b/tests/moe_test.py
@@ -64,7 +64,7 @@ class MoETest(TestCommons):
                 False,
             ],  # is_compiling
             [False, True],  # add_bias
-            [False, True],  # use_quack_gemm
+            [ActivationType.SWIGLU, ActivationType.RELU_SQ],
         )
     )
     def test_moe(
@@ -75,11 +75,8 @@ class MoETest(TestCommons):
         kernel_backend_moe: KernelBackendMoE,
         is_compiling: bool,
         add_bias: bool,
-        use_quack_gemm: bool,
+        activation_type: ActivationType,
     ) -> None:
-        if use_quack_gemm and (is_compiling or add_bias):
-            self.skipTest("unsupported test")
-
         self.set_seed(_SEED)
 
         T, H, I, E, K = problem_shape
@@ -90,7 +87,7 @@ class MoETest(TestCommons):
                 num_experts_per_tok=K,
                 hidden_size=H,
                 intermediate_size=I,
-                activation_function=ActivationType.SWIGLU,
+                activation_function=activation_type,
                 add_bias=add_bias,
                 std=0.02,
             ).to(dtype=dtype)


### PR DESCRIPTION
Related Issue: #61 

## Background

SonicMoE’s QuACK path previously used `gemm_gated` / `gemm_dgated` and
explicitly restricted the supported activations to GLU variants.

QuACK 0.6.4 provides the unified `gemm_act` / `gemm_dact` APIs for both gated
and non-gated activations. Its non-gated backward path also supports
`colvec_scale` and `colvec_reduce`.

This PR updates SonicMoE to use the unified QuACK APIs so that QuACK-supported
gated and non-gated activations can share the existing fused execution path.

## Changes

- Bump the minimum `quack-kernels` version to 0.6.4 
- Replace `gemm_gated` with the unified `gemm_act` API
- Replace `gemm_dgated` with the unified `gemm_dact` API
- Remove the GLU-only assertions from the SonicMoE path
- Prevent the gated weight concat layout from being applied to non-gated activations
- Replace the unused `use_quack_gemm` test dimension with a
  `SWIGLU` / `RELU_SQ` activation dimension
- Remove the existing 13 skipped test cases

## Support and test scope

The implementation passes activations supported by QuACK through the common
`gemm_act` / `gemm_dact` path.

The permanent regression test matrix in this PR covers:

- `SWIGLU`: regression coverage for the existing gated path
- `RELU_SQ`: coverage for the new non-gated path

Both activations are tested across the existing shape matrix with and without
bias. Forward outputs and backward gradients are compared against the PyTorch
reference implementation.

`GELU` is not included in the support or test scope of this PR because
SonicMoE uses `"gelu"` while QuACK provides `"gelu_tanh_approx"`.

## Testing
- GPU: NVIDIA H200
- Python: 3.12.3

<img width="1738" height="452" alt="image" src="https://github.com/user-attachments/assets/5a858aa0-20db-4a0d-b854-1f0cd017bef3" />

