### PR TITLE
Fix index overflow in backward db2/ds kernel

### DIFF
--- a/sonicmoe/functional/backward.py
+++ b/sonicmoe/functional/backward.py
@@ -69,10 +69,10 @@ def db2_and_ds_kernel(
         tk_grouped = E_count_start + tk_offsets
 
         # Gather token indices: [BLOCK_TK]
-        token_indices = tl.load(x_gather_idx_ptr + tk_grouped, mask=tk_mask, other=0).to(tl.uint32)
+        token_indices = tl.load(x_gather_idx_ptr + tk_grouped, mask=tk_mask, other=0).to(tl.int64)
 
         # Get scatter indices: [BLOCK_TK]
-        scatter_indices = tl.load(s_scatter_idx_ptr + tk_grouped, mask=tk_mask, other=0).to(tl.uint32)
+        scatter_indices = tl.load(s_scatter_idx_ptr + tk_grouped, mask=tk_mask, other=0).to(tl.int64)
 
         s = tl.load(s_ptr + scatter_indices, mask=tk_mask, other=0.0).to(tl.float32)
 


### PR DESCRIPTION
We experienced train-inference mismatch while doing RL on a 120B hybrid mixture-of-experts model (`nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16`), and we tracked it down to the expert-aggregation index overflow reported in #23. 

We found that #52 delivers a fix for #23 on the forward gather but leaves the backwards db2/ds kernel's  `token_indices` and `scatter_indices` on uint32. This wraps when $T \times H \geq 2^{32}$, corrupting dbs/d2.

 This PR fixes the issue on the backwards pass.
