### PR TITLE
[feat] Support reproducible MoE fwd/bwd via fixed Triton tiles

### DIFF
--- a/sonicmoe/functional/backward.py
+++ b/sonicmoe/functional/backward.py
@@ -195,13 +195,17 @@ def _up_projection_backward_act(
 
     # db1 computation
     if db1 is not None:
-        db1_kernel[(E,)](
+        deterministic = torch.are_deterministic_algorithms_enabled()
+        kernel = db1_kernel.fn if deterministic else db1_kernel
+        tile = dict(BLOCK_TK=16, BLOCK_I=1024, num_warps=8, num_stages=4) if deterministic else {}
+        kernel[(E,)](
             dh,
             db1,
             expert_frequency_offset,
             (2 * I if is_glu_activation else I),
             E,
             CONCAT_LAYOUT=concat_layout and is_glu_activation,
+            **tile,
         )
 
 
@@ -254,7 +258,10 @@ def _down_projection_backward_act(
         NUM_H_BLOCKS = triton.cdiv(H, BLOCK_H)
         new_ds_partial = torch.empty(TK, NUM_H_BLOCKS, dtype=torch.float32, device=ds.device)
 
-        db2_and_ds_kernel[(E, NUM_H_BLOCKS)](
+        deterministic = torch.are_deterministic_algorithms_enabled()
+        kernel = db2_and_ds_kernel.fn if deterministic else db2_and_ds_kernel
+        tile = dict(BLOCK_TK=16, num_warps=8, num_stages=4) if deterministic else {}
+        kernel[(E, NUM_H_BLOCKS)](
             dout,
             topk_scores,
             new_ds_partial,
@@ -269,6 +276,7 @@ def _down_projection_backward_act(
             1,  # OLD_DS_PARTIAL_N = 1
             BLOCK_H=BLOCK_H,
             BLOCK_OLD_DS_PARTIAL_N=1,
+            **tile,
         )
 
         if NUM_H_BLOCKS == 1:

--- a/sonicmoe/functional/reduction_over_k_gather.py
+++ b/sonicmoe/functional/reduction_over_k_gather.py
@@ -143,7 +143,10 @@ def token_gather_and_sum_varlen_K_triton(
     """
 
     # 1D grid over T only
-    token_gather_sum_kernel[(T,)](
+    deterministic = torch.are_deterministic_algorithms_enabled()
+    kernel = token_gather_sum_kernel.fn if deterministic else token_gather_sum_kernel
+    tile = dict(BLOCK_H=1024, BLOCK_K=1, num_warps=8, num_stages=4) if deterministic else {}
+    kernel[(T,)](
         x,
         w,
         M_perm,
@@ -158,4 +161,5 @@ def token_gather_and_sum_varlen_K_triton(
         stride_outH=out.stride(1),
         w_is_None=(w is None),
         is_varlen_K=is_varlen_K,
+        **tile,
     )


### PR DESCRIPTION
Skip Triton autotune on db1, db2/ds, and token gather-sum when torch.use_deterministic_algorithms is enabled so FP reduction order stays stable across runs.

- When that flag is set, skip Triton autotune on `db1`, `db2_and_ds`, and token gather-sum, and launch the kernels with a fixed tile config so FP reduction order does not change across runs or machines.
- Default (autotuned) path is unchanged.